### PR TITLE
FEAT: Add ratings schedule and map numerical rating to text rating

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,16 @@ their accounts from all their brokerages or, they can upload individual CSV file
 
 
 # Features
-Stock Portfolio Dashboard features:
+
+Portfolio Overview
+* Portfolio Overview uses a combination of IEX Cloud's `/stock` and `/time-series/CORE_ESTIMATES/{symbol}` endpoints to 
+  populate the portfolio with relevant market data. Investors can use this snapshot to quickly understand a portfolio 
+  before diving into further analysis using the "Breakdown" features. Importantly, this snapshot gives investors the 
+  current Consensus Analyst Recommendations and Price Targets for each symbol in the portfolio, which is a helpful 
+  data point when comparing portfolio composition in relation to expectations from professional Wall Street analysts.
+  
+* `/time-series/CORE_ESTIMATES/{symbol}` is a paid core data endpoint. As a result, developers who want to extend this 
+  application need access to a token with a paid subscription.
 
 Stock Breakdown
 * Stock Breakdown uses IEX Cloud's `latestPrice` attribute to calculate the total market value for each symbol in the 
@@ -31,15 +40,15 @@ Stock Breakdown
   will be used.
   
 Sector Breakdown
-* Sector breakdown uses IEX Cloud's `sector` attribute to build sector allocation visualizations. The `sector` refers 
+* Sector Breakdown uses IEX Cloud's `sector` attribute to build sector allocation visualizations. The `sector` refers 
   to the sector a security belongs to.
   
 Market Cap Breakdown
-* Market cap breakdown uses IEX Cloud's `marketCap` attribute to build market cap allocation visualizations for each 
+* Market Cap Breakdown uses IEX Cloud's `marketCap` attribute to build market cap allocation visualizations for each 
   company in the portfolio. The `marketCap` of a security is calculated as shares outstanding * previous day close.
 
-Each feature `GETS` data from IEX Cloud's `/stock` endpoint using a batch call. Batch calls can return data on up to 
-one hundred symbols per request, significantly reducing network traffic.
+Each "Breakdown" feature `GETS` data from IEX Cloud's `/stock` endpoint using a batch call. Batch calls can return data 
+on up to one hundred symbols per request, significantly reducing network traffic.
 
 # Frameworks, Libraries, and Tools
 Spring Cloud:

--- a/src/main/java/edu/bu/cs673/stockportfolio/domain/investment/analysts/AnalystRecommendation.java
+++ b/src/main/java/edu/bu/cs673/stockportfolio/domain/investment/analysts/AnalystRecommendation.java
@@ -52,6 +52,14 @@ public class AnalystRecommendation {
         this.quotes = quotes;
     }
 
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     @JsonProperty("symbol")
     public String getSymbol() {
         return symbol;

--- a/src/main/java/edu/bu/cs673/stockportfolio/service/company/CompanyService.java
+++ b/src/main/java/edu/bu/cs673/stockportfolio/service/company/CompanyService.java
@@ -7,8 +7,10 @@ import org.springframework.stereotype.Service;
 import edu.bu.cs673.stockportfolio.domain.investment.quote.Quote;
 import edu.bu.cs673.stockportfolio.domain.investment.sector.Company;
 import edu.bu.cs673.stockportfolio.domain.investment.sector.CompanyRepository;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class CompanyService {
 
     private final CompanyRepository companyRepository;

--- a/src/main/java/edu/bu/cs673/stockportfolio/service/portfolio/schedulingconfigs/AnalystRecommendationScheduler.java
+++ b/src/main/java/edu/bu/cs673/stockportfolio/service/portfolio/schedulingconfigs/AnalystRecommendationScheduler.java
@@ -1,0 +1,33 @@
+package edu.bu.cs673.stockportfolio.service.portfolio.schedulingconfigs;
+
+import edu.bu.cs673.stockportfolio.service.portfolio.AnalystRecommendationService;
+import org.fissore.slf4j.FluentLogger;
+import org.fissore.slf4j.FluentLoggerFactory;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+public class AnalystRecommendationScheduler {
+    private static final FluentLogger LOGGER = FluentLoggerFactory.getLogger(LatestPriceScheduler.class);
+    private final AnalystRecommendationService analystRecommendationService;
+
+    public AnalystRecommendationScheduler(AnalystRecommendationService analystRecommendationService) {
+        this.analystRecommendationService = analystRecommendationService;
+    }
+
+    /**
+     * Configures the schedule for getting updated market quotes from IEX Cloud. The task uses cron scheduling to run
+     * every minute from 9:00 AM to 4:00 PM Eastern time every day-of-week from Monday through Friday.
+     *
+     * @Note The zone must be updated to either EDT or EST. EDT is represented by GMT−4 and EST is represented by
+     *         GMT−5. EST runs from March to November. It starts during the first Sunday of November until the
+     *         second Sunday of March. In the second Sunday of March, clocks switch into the Eastern Daylight Time
+     */
+    @Scheduled(cron = "0 0 9 * * FRI", zone = "GMT−4")
+    public void startSchedule() {
+        LOGGER.info().log("Get latest analyst recommendations from IEX Cloud");
+        analystRecommendationService.getAnalystRecommendations();
+    }
+}

--- a/src/main/java/edu/bu/cs673/stockportfolio/service/portfolio/schedulingconfigs/LatestPriceScheduler.java
+++ b/src/main/java/edu/bu/cs673/stockportfolio/service/portfolio/schedulingconfigs/LatestPriceScheduler.java
@@ -10,14 +10,14 @@ import org.springframework.scheduling.annotation.Scheduled;
 
 @Configuration
 @EnableScheduling
-public class MarketDataScheduler {
+public class LatestPriceScheduler {
 
-    private static final FluentLogger LOGGER = FluentLoggerFactory.getLogger(MarketDataScheduler.class);
+    private static final FluentLogger LOGGER = FluentLoggerFactory.getLogger(LatestPriceScheduler.class);
     private final MarketDataServiceImpl marketDataServiceImpl;
     private final QuoteService quoteService;
 
-    public MarketDataScheduler(MarketDataServiceImpl marketDataServiceImpl,
-                               QuoteService quoteService) {
+    public LatestPriceScheduler(MarketDataServiceImpl marketDataServiceImpl,
+                                QuoteService quoteService) {
         this.marketDataServiceImpl = marketDataServiceImpl;
         this.quoteService = quoteService;
     }

--- a/src/main/java/edu/bu/cs673/stockportfolio/service/utilities/MarketCapType.java
+++ b/src/main/java/edu/bu/cs673/stockportfolio/service/utilities/MarketCapType.java
@@ -10,7 +10,7 @@ public enum MarketCapType {
     private final long minimum;
     private final long maximum;
 
-    private MarketCapType(long minimum, long maximum) {
+    MarketCapType(long minimum, long maximum) {
         this.minimum = minimum;
         this.maximum = maximum; 
     }

--- a/src/main/java/edu/bu/cs673/stockportfolio/service/utilities/RatingType.java
+++ b/src/main/java/edu/bu/cs673/stockportfolio/service/utilities/RatingType.java
@@ -1,0 +1,28 @@
+package edu.bu.cs673.stockportfolio.service.utilities;
+
+/**********************************************************************************************************************
+ * A mapping of current and historical consensus analyst recommendations and price targets
+ *********************************************************************************************************************/
+public enum RatingType {
+    STRONG_BUY(100F, Float.MAX_VALUE),
+    BUY(50F, 99F),
+    HOLD(-49F, 49F),
+    SELL(-99F, -50F),
+    STRONG_SELL(Float.MIN_VALUE, -100F);
+
+    private final Float minimum;
+    private final Float maximum;
+
+    RatingType(Float minimum, Float maximum) {
+        this.minimum = minimum;
+        this.maximum = maximum;
+    }
+
+    public Float getMaximum() {
+        return maximum;
+    }
+
+    public Float getMinimum() {
+        return minimum;
+    }
+}


### PR DESCRIPTION
Analyst ratings are typically updated after earnings events or other major company announcements. They are not static. The ratings will now be updated every Friday using Springs cron scheduling

IEX Cloud provide consensus estimates in numerical form; however, investors are accustomed to seeing a text form of BUY/HOLD/SELL, so the application creates a mapping between the two to provide a better UX